### PR TITLE
Remove empty `requirements` section

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,8 +13,6 @@ build:
   number: 0
   skip: True  # [win]
 
-requirements:
-
 test:
   commands:
     - test -e $PREFIX/lib/libunistring.so  # [linux]


### PR DESCRIPTION
Fixes https://github.com/conda-forge/libunistring-feedstock/issues/2

Turns out this empty requirements section may be causing us issues running out team update script.

cc @pelson @ericdill
