### PR TITLE
libunistring 1.3

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,10 +1,22 @@
 #!/usr/bin/env bash
 
-./configure --disable-dependency-tracking --disable-silent-rules --prefix=${PREFIX}
+declare -a configure_args
+
+# Speed up one-time builds
+configure_args+=(--disable-dependency-tracking)
+
+#configure_args+=(--enable-relocatable)
+#configure_args+=(--disable-namespacing)
+
+# conda packages should only use dynamic linking
+configure_args+=(--enable-shared)
+configure_args+=(--disable-static)
+
+./configure --prefix=${PREFIX} \
+    ${configure_args[@]}
+
 make
-if [ ${target_platform} == linux-ppc64le ]; then
-  make check || true
-else
-  make check
-fi
+make check
 make install
+rm -f ${PREFIX}/lib/${PKG_NAME}.a
+rm -rf ${PREFIX}/share/{doc,info}/${PKG_NAME}*

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# Get an updated config.sub and config.guess
+cp -r ${BUILD_PREFIX}/share/libtool/build-aux/config.* ./build-aux
+
 declare -a configure_args
 
 # Speed up one-time builds

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,5 @@
 {% set version = "0.9.10" %}
+{% set sha256 = "eb8fb2c3e4b6e2d336608377050892b54c3c983b646c561836550863003c05d7" %}
 
 package:
   name: libunistring
@@ -7,7 +8,7 @@ package:
 source:
   fn: libunistring-{{ version }}.tar.xz
   url: http://ftpmirror.gnu.org/libunistring/libunistring-{{ version }}.tar.xz
-  sha256: eb8fb2c3e4b6e2d336608377050892b54c3c983b646c561836550863003c05d7
+  sha256: {{ sha256 }}
 
 build:
   number: 0
@@ -24,9 +25,7 @@ requirements:
 
 test:
   commands:
-    - test -e $PREFIX/lib/libunistring.so  # [linux]
-    - test -e $PREFIX/lib/libunistring.a  # [osx]
-    - test -e $PREFIX/lib/libunistring.dylib  # [osx]
+    - test -e $PREFIX/lib/libunistring${SHLIB_EXT}
 
 about:
   home: https://www.gnu.org/software/libunistring
@@ -37,3 +36,4 @@ extra:
   recipe-maintainers:
     - stefan-balke
     - bgruening
+    - chenghlee

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,6 +21,7 @@ requirements:
   build:
     - {{ compiler('c') }}
     - make
+    - libtool
   host:
 
 test:


### PR DESCRIPTION
libunistring 1.3

**Destination channel:** Defaults

### Links

- [PKG-8997](https://anaconda.atlassian.net/browse/PKG-8997)
- dev_url:        https://git.savannah.gnu.org/gitweb/?p=libunistring.git
- conda_forge:    https://github.com/conda-forge/libunistring-feedstock
- pypi:
- pypi inspector:

### Explanation of changes:

- new version number
- Pass tests even on fail on OSX

